### PR TITLE
A_Chase fixes

### DIFF
--- a/A_Chase.txt
+++ b/A_Chase.txt
@@ -30,7 +30,7 @@ class PortedActor : Actor
 		}
 
 		// modify target threshold
-		if (target != null || target.Health <= 0)
+		if (target == null || target.Health <= 0)
 			threshold = 0;
 		else
 			threshold--;

--- a/A_Chase.txt
+++ b/A_Chase.txt
@@ -210,7 +210,11 @@ class PortedActor : Actor
 				return;
 			}
 		}
-		if (goal == target) A_PortedDoChaseEnd (fastChase, meleestate, missilestate, playActive, nightmareFast, dontMove, flags);
+		if (goal == target)
+		{
+			A_PortedDoChaseEnd (fastChase, meleestate, missilestate, playActive, nightmareFast, dontMove, flags);
+			return;
+		}
 
 		// Strafe	(Hexen's class bosses)
 		// This was the sole reason for the separate A_FastChase function but
@@ -265,11 +269,13 @@ class PortedActor : Actor
 				if(!isFast && movecount)
 				{
 					A_PortedDoChaseEnd (fastChase, meleestate, missilestate, playActive, nightmareFast, dontMove, flags);
+					return;
 				}
 
 				if (!CheckMissileRange())
 				{
 					A_PortedDoChaseEnd (fastChase, meleestate, missilestate, playActive, nightmareFast, dontMove, flags);
+					return;
 				}
 				SetState (missilestate);
 				bJUSTATTACKED = true;
@@ -357,9 +363,27 @@ class PortedActor : Actor
 
 	}
 
-	action void A_PortedChase (StateLabel melee = null, StateLabel missile = null, int flags = 0)
+	action void A_PortedChase (StateLabel melee = "_a_chase_default", StateLabel missile = "_a_chase_default", int flags = 0)
 	{
-        invoker.A_PortedDoChase ((flags & CHF_FastChase), ResolveState (melee), ResolveState (missile), !(flags & CHF_NoPlayActive),
+		State meleestate;
+		State missilestate;
+		if (melee == "_a_chase_default")
+		{
+			meleestate = invoker.meleestate;
+		}
+		else
+		{
+			meleestate = ResolveState(melee);
+		}
+		if (missile == "_a_chase_default")
+		{
+			missilestate = invoker.missilestate;
+		}
+		else
+		{
+			missilestate = ResolveState(missile);
+		}
+        invoker.A_PortedDoChase ((flags & CHF_FastChase), meleestate, missilestate, !(flags & CHF_NoPlayActive),
             (flags & CHF_NightmareFast), (flags & CHF_DontMove), flags
         );
     }


### PR DESCRIPTION
I just came across this repo looking for a ZScript port of A_Chase. It seems to work mostly like the built-in A_Chase function, but there are a few bugs. This PR fixes them.

- Bug: Some "goto" statements from the original code were converted into function calls. Problem is, unlike goto statements, function calls return, so the code that comes after the call executes when it shouldn't. A visible consequence of this is that monsters become very aggressive, as if "fast monsters" is always on.
  - Fix: Return statements were added after the function calls to prevent the rest of the code from running
- Bug: When calling the built-in A_Chase without arguments, the melee/missile states are assumed to be states named "Melee"/"Missile". The current version of A_PortedChase causes monsters not to attack because the default states are null.
  - Fix: Default states were changed to be the same as A_Chase, based on how the original code works
- Bug: A check that was "target == null" somehow became "target != null", which was causing VM crashes (due to the following check "target.Health <= 0" assuming that target wasn't null)
  - Fix: Changed to "target == null"